### PR TITLE
[Feat] 휴가 신청/사용 내역 조회 및 휴가 사용 현황 데이터 연동 완료

### DIFF
--- a/src/apis/scheduleRequests.ts
+++ b/src/apis/scheduleRequests.ts
@@ -1,5 +1,11 @@
 import { client } from 'apis/index'
-import { IBaseResponse, IDataResponse, ICalendarUser, IDayOffRequest } from 'types/index'
+import {
+  IBaseResponse,
+  IDataResponse,
+  ICalendarUser,
+  IDayOffRequest,
+  IDayOffResponse
+} from 'types/index'
 
 export const getCalendarUserList = async (): Promise<IDataResponse<ICalendarUser[]>> => {
   const response = await client.get('/mypage/schedule/userList')
@@ -9,6 +15,17 @@ export const getCalendarUserList = async (): Promise<IDataResponse<ICalendarUser
 // 연차 신청
 export const insertDayOff = async (params: IDayOffRequest): Promise<IBaseResponse> => {
   const response = await client.post('/mypage/dayoff/register', params, {
+    headers: {
+      // TODO : 토큰 값 수정
+      Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyMDFAYWRtaW4uY29tIiwicm9sZSI6IuydvOuwmCIsImlkIjoxMiwiZXhwIjoxNjkxMjk4OTk5fQ.lu3OkypFGrYJ5BofmO89eE7T8r3sjLRpkdnUbUvuRsvKd5y7z5ImW-0ZPnUUEKn0Sf0Omon6EhJPsO5QlZ4DWQ`
+    }
+  })
+  return response.data
+}
+
+// 연차 신청/사용 내역 조회
+export const fetchDayOffList = async (): Promise<IDataResponse<IDayOffResponse[]>> => {
+  const response = await client.get('/mypage/dayoffList', {
     headers: {
       // TODO : 토큰 값 수정
       Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyMDFAYWRtaW4uY29tIiwicm9sZSI6IuydvOuwmCIsImlkIjoxMiwiZXhwIjoxNjkxMjk4OTk5fQ.lu3OkypFGrYJ5BofmO89eE7T8r3sjLRpkdnUbUvuRsvKd5y7z5ImW-0ZPnUUEKn0Sf0Omon6EhJPsO5QlZ4DWQ`

--- a/src/components/common/SkeletonTable.tsx
+++ b/src/components/common/SkeletonTable.tsx
@@ -1,0 +1,45 @@
+import { Skeleton, SkeletonProps, Table } from 'antd'
+import { ColumnsType } from 'antd/lib/table'
+
+export type SkeletonTableColumnsType = {
+  key: string
+}
+
+type SkeletonTableProps<T> = SkeletonProps & {
+  columns: ColumnsType<T>
+  rowCount?: number
+}
+
+export const SkeletonTable = <T extends object>({
+  loading = false,
+  rowCount = 5,
+  columns,
+  children
+}: SkeletonTableProps<T>) => {
+  return loading ? (
+    <Table
+      size="middle"
+      rowKey="key"
+      pagination={false}
+      dataSource={[...Array(rowCount)] as T[]}
+      columns={columns.map(column => {
+        return {
+          ...column,
+          render: function renderPlaceholder() {
+            return (
+              <Skeleton
+                key={column.key}
+                title
+                active
+                paragraph={false}
+                style={{ padding: '12 8' }}
+              />
+            )
+          }
+        }
+      })}
+    />
+  ) : (
+    <>{children}</>
+  )
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
-export * from '@/components/common/NavLayout'
-export * from '@/components/common/AppNav'
-export * from '@/components/common/NotificationPopup'
+export * from 'components/common/NavLayout'
+export * from 'components/common/AppNav'
+export * from 'components/common/NotificationPopup'
+export * from 'components/common/SkeletonTable'

--- a/src/components/dayoff/DayOffHistoryTable.tsx
+++ b/src/components/dayoff/DayOffHistoryTable.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { DUMMY_DAYOFF_REQUEST_LIST } from 'constants/index'
 import { IDayOffResponse } from 'types/index'
 import { Table, Tag, Typography } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { styled } from 'styled-components'
+import dayjs from 'dayjs'
 
 const { Text } = Typography
 
@@ -17,7 +17,9 @@ const getDayOffHistoryColumns = (): ColumnsType<IDayOffResponse> => [
       <StatusWrapper>
         <IconBox>🏖️</IconBox>
         <StatusBox>
-          <Tag bordered={false}>{status}</Tag>
+          <Tag bordered={false} style={{ minWidth: 60, textAlign: 'center' }}>
+            {status}
+          </Tag>
         </StatusBox>
       </StatusWrapper>
     ),
@@ -45,7 +47,9 @@ const getDayOffHistoryColumns = (): ColumnsType<IDayOffResponse> => [
     key: 'type',
     render: (type: string) => (
       <Type>
-        <Tag color="green">{type}</Tag>
+        <Tag color="green" style={{ minWidth: 60, textAlign: 'center' }}>
+          {type}
+        </Tag>
       </Type>
     ),
     filters: [
@@ -84,10 +88,12 @@ const getDayOffHistoryColumns = (): ColumnsType<IDayOffResponse> => [
     title: '사유',
     dataIndex: 'reason',
     key: 'reason',
-    render: (_, { reason }) => (
+    render: (_, { reason, type, endDate, startDate }) => (
       <ReasonCellWrapper>
         <ReasonText>{reason}</ReasonText>
-        <Tag bordered={false}>1일</Tag>
+        <Tag bordered={false} style={{ minWidth: 45, textAlign: 'center' }}>
+          {type === '연차' ? dayjs(endDate).diff(dayjs(startDate), 'day') + 1 : 0.5}일
+        </Tag>
       </ReasonCellWrapper>
     )
   }
@@ -100,7 +106,7 @@ type DayOffHistorytTableProps = {
 export const DayOffHistorytTable = React.memo(({ historyList }: DayOffHistorytTableProps) => {
   const columns = getDayOffHistoryColumns()
 
-  return <Table columns={columns} dataSource={DUMMY_DAYOFF_REQUEST_LIST} />
+  return <Table columns={columns} dataSource={historyList} />
 })
 
 const StatusWrapper = styled.div`

--- a/src/components/dayoff/DayOffHistoryTable.tsx
+++ b/src/components/dayoff/DayOffHistoryTable.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { IDayOffResponse } from 'types/index'
 import { SkeletonTable } from 'components/index'
+import { calcNumOfDayOff } from 'utils/index'
 
 import { Table, Tag, Typography } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { styled } from 'styled-components'
-import dayjs from 'dayjs'
 
 const { Text } = Typography
 
@@ -94,7 +94,7 @@ const getDayOffHistoryColumns = (): ColumnsType<IDayOffResponse> => [
       <ReasonCellWrapper>
         <ReasonText>{reason}</ReasonText>
         <Tag bordered={false} style={{ minWidth: 45, textAlign: 'center', marginRight: 10 }}>
-          {type === '연차' ? dayjs(endDate).diff(dayjs(startDate), 'day') + 1 : 0.5}일
+          {type === '연차' ? calcNumOfDayOff(startDate, endDate!) : 0.5}일
         </Tag>
       </ReasonCellWrapper>
     )

--- a/src/components/dayoff/DayOffHistoryTable.tsx
+++ b/src/components/dayoff/DayOffHistoryTable.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { IDayOffResponse } from 'types/index'
+import { SkeletonTable } from 'components/index'
+
 import { Table, Tag, Typography } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { styled } from 'styled-components'
@@ -91,7 +93,7 @@ const getDayOffHistoryColumns = (): ColumnsType<IDayOffResponse> => [
     render: (_, { reason, type, endDate, startDate }) => (
       <ReasonCellWrapper>
         <ReasonText>{reason}</ReasonText>
-        <Tag bordered={false} style={{ minWidth: 45, textAlign: 'center' }}>
+        <Tag bordered={false} style={{ minWidth: 45, textAlign: 'center', marginRight: 10 }}>
           {type === '연차' ? dayjs(endDate).diff(dayjs(startDate), 'day') + 1 : 0.5}일
         </Tag>
       </ReasonCellWrapper>
@@ -101,13 +103,20 @@ const getDayOffHistoryColumns = (): ColumnsType<IDayOffResponse> => [
 
 type DayOffHistorytTableProps = {
   historyList: IDayOffResponse[]
+  isLoading: boolean
 }
 
-export const DayOffHistorytTable = React.memo(({ historyList }: DayOffHistorytTableProps) => {
-  const columns = getDayOffHistoryColumns()
+export const DayOffHistorytTable = React.memo(
+  ({ historyList, isLoading }: DayOffHistorytTableProps) => {
+    const columns = getDayOffHistoryColumns()
 
-  return <Table columns={columns} dataSource={historyList} />
-})
+    return (
+      <SkeletonTable loading={isLoading} columns={columns as ColumnsType<IDayOffResponse[]>}>
+        <Table size="middle" columns={columns} dataSource={historyList} />
+      </SkeletonTable>
+    )
+  }
+)
 
 const StatusWrapper = styled.div`
   display: flex;
@@ -124,6 +133,7 @@ const IconBox = styled.div`
   justify-content: center;
   align-items: center;
   background-color: var(--color-white);
+  margin-left: 10px;
 `
 
 const StatusBox = styled.div`

--- a/src/components/dayoff/DayOffRequestTable.tsx
+++ b/src/components/dayoff/DayOffRequestTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { DAYOFF_MENU_ITEMS, DUMMY_DAYOFF_REQUEST_LIST } from 'constants/index'
+import { DAYOFF_MENU_ITEMS } from 'constants/index'
 import { IDayOffResponse } from 'types/index'
 
 import { EllipsisOutlined } from '@ant-design/icons'
@@ -7,6 +7,7 @@ import { Table, Tag, Dropdown } from 'antd'
 import type { MenuProps } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { styled } from 'styled-components'
+import dayjs from 'dayjs'
 
 const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<IDayOffResponse> => [
   {
@@ -18,7 +19,12 @@ const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<I
       <StatusWrapper>
         <IconBox>🏖️</IconBox>
         <StatusBox>
-          <Tag bordered={false}>{status}</Tag>
+          <Tag
+            bordered={false}
+            color={status === '반려' ? 'error' : 'default'}
+            style={{ minWidth: 60, textAlign: 'center' }}>
+            {status}
+          </Tag>
         </StatusBox>
       </StatusWrapper>
     ),
@@ -46,7 +52,9 @@ const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<I
     key: 'type',
     render: (type: string) => (
       <Type>
-        <Tag color="green">{type}</Tag>
+        <Tag color="green" style={{ minWidth: 60, textAlign: 'center' }}>
+          {type}
+        </Tag>
       </Type>
     ),
     filters: [
@@ -70,13 +78,15 @@ const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<I
     title: '휴가 일자',
     dataIndex: ['startDate', 'endDate'],
     key: 'date',
-    render: (_, { startDate, endDate }) => (
+    render: (_, { startDate, endDate, type }) => (
       <DateCellWrapper>
         <DateWrapper>
           {startDate}
           {endDate ? ` ~ ${endDate}` : ''}
         </DateWrapper>
-        <Tag bordered={false}>1일</Tag>
+        <Tag bordered={false} style={{ minWidth: 45, textAlign: 'center' }}>
+          {type === '연차' ? dayjs(endDate).diff(dayjs(startDate), 'day') + 1 : 0.5}일
+        </Tag>
         <Dropdown menu={{ items: DAYOFF_MENU_ITEMS, onClick: menuClick }} trigger={['click']}>
           <EllipsisOutlined />
         </Dropdown>
@@ -93,13 +103,13 @@ type DayOffRequestTableProps = {
 }
 
 export const DayOffRequestTable = React.memo(({ requestList }: DayOffRequestTableProps) => {
-  const onClickCancel: MenuProps['onClick'] = ({ key }) => {
+  const onClickCancel: MenuProps['onClick'] = () => {
     // TODO : 신청 취소 기능
   }
 
   const columns = getDayOffRequestColumns(onClickCancel)
 
-  return <Table columns={columns} dataSource={DUMMY_DAYOFF_REQUEST_LIST} />
+  return <Table columns={columns} dataSource={requestList} pagination={{ pageSize: 5 }} />
 })
 
 const StatusWrapper = styled.div`

--- a/src/components/dayoff/DayOffRequestTable.tsx
+++ b/src/components/dayoff/DayOffRequestTable.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { DAYOFF_MENU_ITEMS } from 'constants/index'
 import { SkeletonTable } from 'components/index'
 import { IDayOffResponse } from 'types/index'
+import { calcNumOfDayOff } from 'utils/index'
 
 import { EllipsisOutlined } from '@ant-design/icons'
 import { Table, Tag, Dropdown } from 'antd'
 import type { MenuProps } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { styled } from 'styled-components'
-import dayjs from 'dayjs'
 
 const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<IDayOffResponse> => [
   {
@@ -86,7 +86,7 @@ const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<I
           {endDate ? ` ~ ${endDate}` : ''}
         </DateWrapper>
         <Tag bordered={false} style={{ minWidth: 45, textAlign: 'center' }}>
-          {type === '연차' ? dayjs(endDate).diff(dayjs(startDate), 'day') + 1 : 0.5}일
+          {type === '연차' ? calcNumOfDayOff(startDate, endDate!) : 0.5}일
         </Tag>
         <Dropdown menu={{ items: DAYOFF_MENU_ITEMS, onClick: menuClick }} trigger={['click']}>
           <EllipsisOutlined style={{ marginRight: 10 }} />

--- a/src/components/dayoff/DayOffRequestTable.tsx
+++ b/src/components/dayoff/DayOffRequestTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { DAYOFF_MENU_ITEMS } from 'constants/index'
+import { SkeletonTable } from 'components/index'
 import { IDayOffResponse } from 'types/index'
 
 import { EllipsisOutlined } from '@ant-design/icons'
@@ -88,7 +89,7 @@ const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<I
           {type === '연차' ? dayjs(endDate).diff(dayjs(startDate), 'day') + 1 : 0.5}일
         </Tag>
         <Dropdown menu={{ items: DAYOFF_MENU_ITEMS, onClick: menuClick }} trigger={['click']}>
-          <EllipsisOutlined />
+          <EllipsisOutlined style={{ marginRight: 10 }} />
         </Dropdown>
       </DateCellWrapper>
     ),
@@ -100,17 +101,29 @@ const getDayOffRequestColumns = (menuClick: MenuProps['onClick']): ColumnsType<I
 
 type DayOffRequestTableProps = {
   requestList: IDayOffResponse[]
+  isLoading: boolean
 }
 
-export const DayOffRequestTable = React.memo(({ requestList }: DayOffRequestTableProps) => {
-  const onClickCancel: MenuProps['onClick'] = () => {
-    // TODO : 신청 취소 기능
+export const DayOffRequestTable = React.memo(
+  ({ requestList, isLoading }: DayOffRequestTableProps) => {
+    const onClickCancel: MenuProps['onClick'] = () => {
+      // TODO : 신청 취소 기능
+    }
+
+    const columns = getDayOffRequestColumns(onClickCancel)
+
+    return (
+      <SkeletonTable loading={isLoading} columns={columns as ColumnsType<IDayOffResponse[]>}>
+        <Table
+          size="middle"
+          columns={columns}
+          dataSource={requestList}
+          pagination={{ pageSize: 5 }}
+        />
+      </SkeletonTable>
+    )
   }
-
-  const columns = getDayOffRequestColumns(onClickCancel)
-
-  return <Table columns={columns} dataSource={requestList} pagination={{ pageSize: 5 }} />
-})
+)
 
 const StatusWrapper = styled.div`
   display: flex;
@@ -127,6 +140,7 @@ const IconBox = styled.div`
   justify-content: center;
   align-items: center;
   background-color: var(--color-white);
+  margin-left: 10px;
 `
 
 const StatusBox = styled.div`

--- a/src/components/dayoff/DayOffSummary.tsx
+++ b/src/components/dayoff/DayOffSummary.tsx
@@ -5,7 +5,12 @@ import { dayOffTypes } from 'constants/index'
 import { Col, Row } from 'antd'
 import { globalToken } from '@/GlobalThemeConfig'
 
-export const DayOffSummary = React.memo(() => {
+type TDayOffSummaryProps = {
+  available: number
+  used: number
+}
+
+export const DayOffSummary = React.memo(({ available, used }: TDayOffSummaryProps) => {
   return (
     <Row
       style={{
@@ -15,13 +20,13 @@ export const DayOffSummary = React.memo(() => {
         flexShrink: 0
       }}>
       <Col span={8}>
-        <MyDayOffCount type={dayOffTypes.AVAILABLE} day={11} />
+        <MyDayOffCount type={dayOffTypes.AVAILABLE} day={available} />
       </Col>
       <Col span={8}>
         <MyDayOffCount type={dayOffTypes.EXTINCTION} day={0} />
       </Col>
       <Col span={8}>
-        <MyDayOffCount type={dayOffTypes.USED} day={4} />
+        <MyDayOffCount type={dayOffTypes.USED} day={used} />
       </Col>
     </Row>
   )

--- a/src/constants/resultModalDatas.ts
+++ b/src/constants/resultModalDatas.ts
@@ -17,5 +17,11 @@ export const resultModalDatas = {
     type: 1,
     okButton: '확인',
     okCallback: () => {}
+  },
+  DAY_OFF_DAYS_VALIDATION: {
+    title: '휴가 등록 오류',
+    content: '잔여 휴가일 보다 많은 휴가를 등록할 수 없습니다.\n잔여 휴가일 : ',
+    type: 1,
+    okButton: '확인'
   }
 }

--- a/src/constants/resultModalDatas.ts
+++ b/src/constants/resultModalDatas.ts
@@ -10,5 +10,12 @@ export const resultModalDatas = {
     type: 1,
     okButton: '확인',
     okCallback: () => {}
+  },
+  DAY_OFF_FETCH_FAILURE: {
+    title: '휴가 내역 조회 실패',
+    content: '휴가 내역을 가져오는 중 오류가 발생했습니다.\n관리자에게 문의해주세요.',
+    type: 1,
+    okButton: '확인',
+    okCallback: () => {}
   }
 }

--- a/src/pages/DayOff.tsx
+++ b/src/pages/DayOff.tsx
@@ -9,7 +9,11 @@ import { IDayOffRequest, IDayOffResponse } from 'types/index'
 import { insertDayOff, fetchDayOffList } from 'apis/index'
 import { modalStore } from 'stores/index'
 import { resultModalDatas } from 'constants/index'
-import { getFilteredDayOffRequestList, getFilteredDayOffHistoryList } from 'utils/index'
+import {
+  getFilteredDayOffRequestList,
+  getFilteredDayOffHistoryList,
+  calcNumOfUsedDayOff
+} from 'utils/index'
 
 import { styled } from 'styled-components'
 
@@ -24,7 +28,8 @@ export const DayOff = () => {
 
   const requestList = useMemo(() => getFilteredDayOffRequestList(dayOffList), [dayOffList])
   const historyList = useMemo(() => getFilteredDayOffHistoryList(dayOffList), [dayOffList])
-
+  const numOfUsedDays = useMemo(() => calcNumOfUsedDayOff(historyList), [historyList])
+  const numOfAvailableDays = useMemo(() => 15 - numOfUsedDays, [numOfUsedDays])
   const getDayOffList = useCallback(() => {
     setIsLoading(true)
     fetchDayOffList()
@@ -89,7 +94,7 @@ export const DayOff = () => {
       </ButtonBox>
       <Wapper>
         <h2>나의 휴가</h2>
-        <DayOffSummary />
+        <DayOffSummary available={numOfAvailableDays} used={numOfUsedDays} />
       </Wapper>
 
       <Wapper>
@@ -106,6 +111,7 @@ export const DayOff = () => {
         <DayOffHistorytTable historyList={historyList} isLoading={isLoading} />
       </Wapper>
       <DayOffRequestModal
+        availableDays={numOfAvailableDays}
         isModalOpen={isModalOpen}
         onClickOk={handleOk}
         onClickCancel={handleCancel}

--- a/src/pages/DayOff.tsx
+++ b/src/pages/DayOff.tsx
@@ -20,20 +20,28 @@ export const DayOff = () => {
   const { openModal } = modalStore()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [dayOffList, setDayOffList] = useState<IDayOffResponse[]>([])
+  const [isLoading, setIsLoading] = useState(false)
 
   const requestList = useMemo(() => getFilteredDayOffRequestList(dayOffList), [dayOffList])
   const historyList = useMemo(() => getFilteredDayOffHistoryList(dayOffList), [dayOffList])
 
-  const getDayOffList = () => {
-    fetchDayOffList().then(
-      res => {
-        setDayOffList(res.data)
-      },
-      () => {
-        openModal(resultModalDatas.DAY_OFF_FETCH_FAILURE)
-      }
-    )
-  }
+  const getDayOffList = useCallback(() => {
+    setIsLoading(true)
+    fetchDayOffList()
+      .then(
+        res => {
+          setDayOffList(res.data)
+        },
+        () => {
+          openModal(resultModalDatas.DAY_OFF_FETCH_FAILURE)
+        }
+      )
+      .finally(() => {
+        setTimeout(() => {
+          setIsLoading(false)
+        }, 400)
+      })
+  }, [])
 
   useEffect(() => {
     getDayOffList()
@@ -88,14 +96,14 @@ export const DayOff = () => {
         <h2>
           휴가 신청 내역 <span>{requestList.length}</span>
         </h2>
-        <DayOffRequestTable requestList={requestList} />
+        <DayOffRequestTable requestList={requestList} isLoading={isLoading} />
       </Wapper>
 
       <Wapper>
         <h2>
           휴가 사용 내역 <span>{historyList.length}</span>
         </h2>
-        <DayOffHistorytTable historyList={historyList} />
+        <DayOffHistorytTable historyList={historyList} isLoading={isLoading} />
       </Wapper>
       <DayOffRequestModal
         isModalOpen={isModalOpen}

--- a/src/utils/calcNumOfDayOff.ts
+++ b/src/utils/calcNumOfDayOff.ts
@@ -1,0 +1,23 @@
+import { IDayOffResponse } from 'types/index'
+import dayjs from 'dayjs'
+
+// 연차 범위 중 주말이 포함 된 경우 주말 제외한 일 수
+export const calcNumOfDayOff = (startDate: string, endDate: string) => {
+  const start = dayjs(startDate)
+  const end = dayjs(endDate)
+  const diffDays = end.diff(start, 'day') + 1
+  const diffWeeks = end.diff(start, 'week')
+
+  if ((startDate !== endDate && end.get('day') <= start.get('day')) || diffWeeks >= 1) {
+    return diffDays - 2 * (diffWeeks === 0 ? 1 : diffWeeks)
+  }
+
+  return diffDays
+}
+
+// 사용한 휴가의 합산
+export const calcNumOfUsedDayOff = (historyList: IDayOffResponse[]) => {
+  return historyList.reduce((acc, cur) => {
+    return (acc += cur.type === '연차' ? calcNumOfDayOff(cur.startDate, cur.endDate!) : 0.5)
+  }, 0)
+}

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -1,0 +1,73 @@
+import { IDayOffResponse } from 'types/index'
+import dayjs from 'dayjs'
+
+// * 신청 내역 필터링 기준
+// * 연차: 오늘 이전, 오전반차: 오늘날짜 9시 이전, 오후반차: 오늘 날짜 14시 이전
+export const getFilteredDayOffRequestList = (dayOffList: IDayOffResponse[]) => {
+  return (
+    dayOffList.filter(data => {
+      switch (data.type) {
+        case '연차':
+          if (dayjs().startOf('date').diff(data.startDate) < 0) {
+            return data
+          }
+          break
+        case '오전반차':
+          if (
+            dayjs().startOf('date').diff(data.startDate) < 0 ||
+            (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') < 9)
+          ) {
+            return data
+          }
+          break
+        case '오후반차':
+          if (
+            dayjs().startOf('date').diff(data.startDate) < 0 ||
+            (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') < 14)
+          ) {
+            return data
+          }
+          break
+        default:
+          break
+      }
+    }) ?? []
+  )
+}
+
+// 사용 내역 필터링
+// * 사용 내역 필터 기준
+// * startDate가 오늘 날짜 이후면서 승인 상태인 경우
+export const getFilteredDayOffHistoryList = (dayOffList: IDayOffResponse[]) => {
+  return (
+    dayOffList
+      .filter(data => {
+        switch (data.type) {
+          case '연차':
+            if (dayjs().startOf('date').diff(data.startDate) >= 0) {
+              return data
+            }
+            break
+          case '오전반차':
+            if (
+              dayjs().startOf('date').diff(data.startDate) >= 0 ||
+              (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') >= 9)
+            ) {
+              return data
+            }
+            break
+          case '오후반차':
+            if (
+              dayjs().startOf('date').diff(data.startDate) >= 0 ||
+              (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') >= 14)
+            ) {
+              return data
+            }
+            break
+          default:
+            break
+        }
+      })
+      .filter(data => data.status === '승인') ?? []
+  )
+}

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -40,34 +40,33 @@ export const getFilteredDayOffRequestList = (dayOffList: IDayOffResponse[]) => {
 // * startDate가 오늘 날짜 이후면서 승인 상태인 경우
 export const getFilteredDayOffHistoryList = (dayOffList: IDayOffResponse[]) => {
   return (
-    dayOffList
-      .filter(data => {
-        switch (data.type) {
-          case '연차':
-            if (dayjs().startOf('date').diff(data.startDate) >= 0) {
-              return data
-            }
-            break
-          case '오전반차':
-            if (
-              dayjs().startOf('date').diff(data.startDate) >= 0 ||
-              (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') >= 9)
-            ) {
-              return data
-            }
-            break
-          case '오후반차':
-            if (
-              dayjs().startOf('date').diff(data.startDate) >= 0 ||
-              (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') >= 14)
-            ) {
-              return data
-            }
-            break
-          default:
-            break
-        }
-      })
-      .filter(data => data.status === '승인') ?? []
+    dayOffList.filter(data => {
+      switch (data.type) {
+        case '연차':
+          if (dayjs().startOf('date').diff(data.startDate) >= 0) {
+            return data
+          }
+          break
+        case '오전반차':
+          if (
+            dayjs().startOf('date').diff(data.startDate) >= 0 ||
+            (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') >= 9)
+          ) {
+            return data
+          }
+          break
+        case '오후반차':
+          if (
+            dayjs().startOf('date').diff(data.startDate) >= 0 ||
+            (dayjs().startOf('date').diff(data.startDate) === 0 && dayjs().get('hour') >= 14)
+          ) {
+            return data
+          }
+          break
+        default:
+          break
+      }
+    }) ?? []
+    // .filter(data => data.status === '승인') ?? []
   )
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from 'utils/filterUtils'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from 'utils/filterUtils'
+export * from 'utils/calcNumOfDayOff'


### PR DESCRIPTION
### 📝 작업내용

- 휴가 페이지 신청 내역 조회
- 휴가 페이지 사용 내역 조회
- 휴가일 주말 제외 계산 로직 추가
- 휴가 사용 현황 데이터 연동 (잔여 휴가, 사용 휴가일 계산 로직 추가)

### 🐞 관련 이슈

closed #34 

### 궁금한 사항 또는 공유할 사항

-잔여 휴가일 계산 클라이언트쪽에서 진행하는 걸로 백엔드분들과 협의
- 위 사유로 인하여 관리자 > 사원조회에서 잔여 휴가일 컬럼 제외
